### PR TITLE
Use Decanter 6.0.1 and add Stanford favicon to the website itself

### DIFF
--- a/content/_kss/markup/identity-lockup-su-lockup--option-a.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-a.html
@@ -5,7 +5,6 @@
   <div class="su-lockup__cell1">
           <div class="su-lockup__wordmark-wrapper">
         <span class="su-lockup__wordmark">Stanford</span>
-                  <span class="su-lockup__line4" >Engineering</span>
               </div>
       </div>
 
@@ -13,8 +12,6 @@
   <div class="su-lockup__cell2">
             <span class="su-lockup__line1" >Finance</span>
     
-        <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
         </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-b.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-b.html
@@ -5,7 +5,6 @@
   <div class="su-lockup__cell1">
           <div class="su-lockup__wordmark-wrapper">
         <span class="su-lockup__wordmark">Stanford</span>
-                  <span class="su-lockup__line4" >Engineering</span>
               </div>
       </div>
 
@@ -15,6 +14,5 @@
     
         <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
-        </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
+        </div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-c.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-c.html
@@ -5,7 +5,6 @@
   <div class="su-lockup__cell1">
           <div class="su-lockup__wordmark-wrapper">
         <span class="su-lockup__wordmark">Stanford</span>
-                  <span class="su-lockup__line4" >Engineering</span>
               </div>
       </div>
 
@@ -15,6 +14,5 @@
     
         <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
         </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-d.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-d.html
@@ -5,7 +5,6 @@
   <div class="su-lockup__cell1">
           <div class="su-lockup__wordmark-wrapper">
         <span class="su-lockup__wordmark">Stanford</span>
-                  <span class="su-lockup__line4" >Engineering</span>
               </div>
       </div>
 
@@ -13,8 +12,7 @@
   <div class="su-lockup__cell2">
             <span class="su-lockup__line1" >Finance</span>
     
-        <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
         <span class="su-lockup__line3" >Mechanical Engineering</span>
-        </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
+        </div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-e.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-e.html
@@ -5,7 +5,6 @@
   <div class="su-lockup__cell1">
           <div class="su-lockup__wordmark-wrapper">
         <span class="su-lockup__wordmark">Stanford</span>
-                  <span class="su-lockup__line4" >Engineering</span>
               </div>
       </div>
 
@@ -16,5 +15,5 @@
         <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
         <span class="su-lockup__line3" >Mechanical Engineering</span>
-        </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
+        </div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-f.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-f.html
@@ -5,7 +5,6 @@
   <div class="su-lockup__cell1">
           <div class="su-lockup__wordmark-wrapper">
         <span class="su-lockup__wordmark">Stanford</span>
-                  <span class="su-lockup__line4" >Engineering</span>
               </div>
       </div>
 
@@ -15,6 +14,5 @@
     
         <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
-        </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
+        </div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-g.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-g.html
@@ -5,7 +5,6 @@
   <div class="su-lockup__cell1">
           <div class="su-lockup__wordmark-wrapper">
         <span class="su-lockup__wordmark">Stanford</span>
-                  <span class="su-lockup__line4" >Engineering</span>
               </div>
       </div>
 
@@ -15,6 +14,5 @@
     
         <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
         </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-h.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-h.html
@@ -13,8 +13,7 @@
   <div class="su-lockup__cell2">
             <span class="su-lockup__line1" >Finance</span>
     
-        <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
         <span class="su-lockup__line3" >Mechanical Engineering</span>
-        </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
+        </div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-i.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-i.html
@@ -13,8 +13,7 @@
   <div class="su-lockup__cell2">
             <span class="su-lockup__line1" >Finance</span>
     
-        <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
         <span class="su-lockup__line3" >Mechanical Engineering</span>
-        </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
+        </div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-j.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-j.html
@@ -5,7 +5,6 @@
   <div class="su-lockup__cell1">
           <div class="su-lockup__wordmark-wrapper">
         <span class="su-lockup__wordmark">Stanford</span>
-                  <span class="su-lockup__line4" >Engineering</span>
               </div>
       </div>
 
@@ -15,6 +14,5 @@
     
         <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
         </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-k.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-k.html
@@ -5,7 +5,6 @@
   <div class="su-lockup__cell1">
           <div class="su-lockup__wordmark-wrapper">
         <span class="su-lockup__wordmark">Stanford</span>
-                  <span class="su-lockup__line4" >Engineering</span>
               </div>
       </div>
 
@@ -13,8 +12,6 @@
   <div class="su-lockup__cell2">
             <span class="su-lockup__line1" >Finance</span>
     
-        <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
         </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-l.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-l.html
@@ -5,7 +5,6 @@
   <div class="su-lockup__cell1">
           <div class="su-lockup__wordmark-wrapper">
         <span class="su-lockup__wordmark">Stanford</span>
-                  <span class="su-lockup__line4" >Engineering</span>
               </div>
       </div>
 
@@ -13,8 +12,6 @@
   <div class="su-lockup__cell2">
             <span class="su-lockup__line1" >Finance</span>
     
-        <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
-        </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
+        </div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-m.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-m.html
@@ -5,7 +5,6 @@
   <div class="su-lockup__cell1">
           <div class="su-lockup__wordmark-wrapper">
         <span class="su-lockup__wordmark">Stanford</span>
-                  <span class="su-lockup__line4" >Engineering</span>
               </div>
       </div>
 
@@ -15,6 +14,5 @@
     
         <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
-        </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
+        </div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-n.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-n.html
@@ -5,7 +5,6 @@
   <div class="su-lockup__cell1">
           <div class="su-lockup__wordmark-wrapper">
         <span class="su-lockup__wordmark">Stanford</span>
-                  <span class="su-lockup__line4" >Engineering</span>
               </div>
       </div>
 
@@ -13,8 +12,6 @@
   <div class="su-lockup__cell2">
             <span class="su-lockup__line1" >Finance</span>
     
-        <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
-        </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
+        </div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-o.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-o.html
@@ -11,10 +11,7 @@
 
   
   <div class="su-lockup__cell2">
-            <span class="su-lockup__line1" >Finance</span>
+        
     
-        <span class="su-lockup__line2" >Program In Thermal Optics</span>
-    
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
-        </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
+        </div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-p.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-p.html
@@ -13,8 +13,6 @@
   <div class="su-lockup__cell2">
             <span class="su-lockup__line1" >Finance</span>
     
-        <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
-        </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
+        </div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-q.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-q.html
@@ -13,8 +13,6 @@
   <div class="su-lockup__cell2">
             <span class="su-lockup__line1" >Finance</span>
     
-        <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
-        </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
+        </div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-r.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-r.html
@@ -5,16 +5,12 @@
   <div class="su-lockup__cell1">
           <div class="su-lockup__wordmark-wrapper">
         <span class="su-lockup__wordmark">Stanford</span>
-                  <span class="su-lockup__line4" >Engineering</span>
               </div>
       </div>
 
   
   <div class="su-lockup__cell2">
-            <span class="su-lockup__line1" >Finance</span>
+        
     
-        <span class="su-lockup__line2" >Program In Thermal Optics</span>
-    
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
         </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-s.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-s.html
@@ -15,6 +15,5 @@
     
         <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
-        <span class="su-lockup__line3" >Mechanical Engineering</span>
-        </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
+        </div>      </a>
   </div>

--- a/content/_kss/markup/identity-lockup-su-lockup--option-t.html
+++ b/content/_kss/markup/identity-lockup-su-lockup--option-t.html
@@ -16,5 +16,5 @@
         <span class="su-lockup__line2" >Program In Thermal Optics</span>
     
         <span class="su-lockup__line3" >Mechanical Engineering</span>
-        </div>    <div class="su-lockup__line5 ">School of Humanities & Sciences</div>      </a>
+        </div>      </a>
   </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4391,7 +4391,7 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decanter": {
-      "version": "git+https://github.com/su-sws/decanter.git#e34d42c175fa2248d38c7f805424dfe8649ec156",
+      "version": "git+https://github.com/su-sws/decanter.git#eedd2dce69a01d3bb9fb6585768466acdbb4caef",
       "from": "git+https://github.com/su-sws/decanter.git#v6",
       "requires": {
         "@fortawesome/fontawesome-free": "^5.11.2",

--- a/src/components/partials/global-head.js
+++ b/src/components/partials/global-head.js
@@ -4,6 +4,30 @@ import "../../scss/index.scss";
 const HTMLHead = props => (
   <>
   <Head>
+    <link rel="apple-touch-icon" sizes="57x57" href="https://www-media.stanford.edu/assets/favicon/apple-touch-icon-57x57.png" />
+    <link rel="apple-touch-icon" sizes="60x60" href="https://www-media.stanford.edu/assets/favicon/apple-touch-icon-60x60.png" />
+    <link rel="apple-touch-icon" sizes="72x72" href="https://www-media.stanford.edu/assets/favicon/apple-touch-icon-72x72.png" />
+    <link rel="apple-touch-icon" sizes="76x76" href="https://www-media.stanford.edu/assets/favicon/apple-touch-icon-76x76.png" />
+    <link rel="apple-touch-icon" sizes="114x114" href="https://www-media.stanford.edu/assets/favicon/apple-touch-icon-114x114.png" />
+    <link rel="apple-touch-icon" sizes="120x120" href="https://www-media.stanford.edu/assets/favicon/apple-touch-icon-120x120.png" />
+    <link rel="apple-touch-icon" sizes="144x144" href="https://www-media.stanford.edu/assets/favicon/apple-touch-icon-144x144.png" />
+    <link rel="apple-touch-icon" sizes="152x152" href="https://www-media.stanford.edu/assets/favicon/apple-touch-icon-152x152.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="https://www-media.stanford.edu/assets/favicon/apple-touch-icon-180x180.png" />
+
+    <link rel="icon" type="image/png" href="https://www-media.stanford.edu/assets/favicon/favicon-196x196.png" sizes="196x196" />
+    <link rel="icon" type="image/png" href="https://www-media.stanford.edu/assets/favicon/favicon-192x192.png" sizes="192x192" />
+    <link rel="icon" type="image/png" href="https://www-media.stanford.edu/assets/favicon/favicon-128.png" sizes="128x128" />
+    <link rel="icon" type="image/png" href="https://www-media.stanford.edu/assets/favicon/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/png" href="https://www-media.stanford.edu/assets/favicon/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="https://www-media.stanford.edu/assets/favicon/favicon-16x16.png" sizes="16x16" />
+
+    <link rel="mask-icon" href="https://www-media.stanford.edu/assets/favicon/safari-pinned-tab.svg" color="#ffffff" />
+    <meta name="application-name" content="Decanter Stanford Design System"/>
+    <meta name="msapplication-TileColor" content="#FFFFFF" />
+    <meta name="msapplication-TileImage" content="https://www-media.stanford.edu/assets/favicon/mstile-144x144.png" />
+    <meta name="msapplication-square70x70logo" content="https://www-media.stanford.edu/assets/favicon/mstile-70x70.png" />
+    <meta name="msapplication-square150x150logo" content="https://www-media.stanford.edu/assets/favicon/mstile-150x150.png" />
+    <meta name="msapplication-square310x310logo" content="https://www-media.stanford.edu/assets/favicon/mstile-310x310.png" />
     <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
   </Head>
   </>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add Stanford favicon (all the different versions for different platforms) to the Decanter site as requested by JB.
- Updated with Decanter 6.0.1

# Needed By (Date)
- anytime

# Urgency
- Not urgent

# Steps to Test

1. Look at the preview and see if the SU favicon is in the browser tab.
https://5e1e37dc57475700084472c8--elegant-poitras-87214a.netlify.com/
2. Look at the code and see if this is the right way to do this.