### PR TITLE
Fix broken link on home page

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -54,7 +54,7 @@ date: 2019-03-17T19:31:20.591Z
 
  <h3>Decanter Design System</h3>
         <p>Familiarize yourself with our foundational styles, components, and naming conventions using the Decanter Design System in Figma.</p>
-        <a href="page/use-decanter-as-a-designer/" class="su-link su-link--action">Learn about the Decanter Design System</a>
+        <a href="page/components/" class="su-link su-link--action">Learn about the Decanter Design System</a>
     </section>
     <section class="flex-md-6-of-12">
         

--- a/content/index.md
+++ b/content/index.md
@@ -54,7 +54,7 @@ date: 2019-03-17T19:31:20.591Z
 
  <h3>Decanter Design System</h3>
         <p>Familiarize yourself with our foundational styles, components, and naming conventions using the Decanter Design System in Figma.</p>
-        <a href="/section-components.html" class="su-link su-link--action">Learn about the Decanter Design System</a>
+        <a href="page/use-decanter-as-a-designer/" class="su-link su-link--action">Learn about the Decanter Design System</a>
     </section>
     <section class="flex-md-6-of-12">
         


### PR DESCRIPTION
# READY FOR REVIEW
- (Edit the above to reflect status)

# Summary
- Fixing a broken link on the home page for Decanter

# Needed By (Date)
- Not that urgent tbh

# Urgency
- Not urgent

# Steps to Test
To see broken link:
1. Go to decanter.stanford.edu
2. Find/click link called "Learn about the Decanter Design System" toward bottom of home page

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?
Affects only the decanter.stanford.edu informational site

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
