### PR TITLE
A11y | Siteimprove fixes

### DIFF
--- a/components/Homepage/Homepage.tsx
+++ b/components/Homepage/Homepage.tsx
@@ -6,7 +6,7 @@ import uiComponents from 'images/ui-components.png';
 import * as routes from 'utils/routes';
 
 export const Homepage = () => (
-  <div id="main-content" className="w-full h-full basefont-20 bg-gradient-to-r from-black to-plum">
+  <main id="main-content" className="w-full h-full basefont-20 bg-gradient-to-r from-black to-plum">
     <section className="rs-py-5 cc">
       <div className="max-w-900 mx-auto">
         <Heading as="h1" size={4} color="white">Welcome to the Decanter Style Guide and Pattern Library</Heading>
@@ -52,5 +52,5 @@ export const Homepage = () => (
         </div>
       </div>
     </section>
-  </div>
+  </main>
 );

--- a/components/SectionNav/SectionNav.tsx
+++ b/components/SectionNav/SectionNav.tsx
@@ -15,7 +15,7 @@ export const SectionNav = ({
   className,
 }: SectionNavProps) => (
   <nav className={dcnb('sticky top-10', className)} aria-label="Section menu">
-    <Heading as="h3" size={1}>On this page</Heading>
+    <Heading as="h2" size={1}>On this page</Heading>
     <ul className="list-unstyled">
       {children}
     </ul>

--- a/content/examples/grid-flex.mdx
+++ b/content/examples/grid-flex.mdx
@@ -7,7 +7,7 @@ lastUpdatedDate: 2023-05-25T12:00:00.000Z
   <Section heading="Flex Box" width="full">
     ```html
     <div class="flex flex-col md:flex-row gap-xs lg:gap-lg xl:gap-xl 2xl:gap-2xl text-white rs-mb-2">
-      <div class="w-full md:w-1/2 bg-palo-verde-light rs-p-2">
+      <div class="w-full md:w-1/2 bg-lagunita rs-p-2">
         <h3>6 of 12 columns</h3>
         <p class="card-paragraph">This column stacks vertically for XS-SM breakpoints and spans 6 of 12
           columns for MD and up; responsive grid gaps.</p>
@@ -19,12 +19,12 @@ lastUpdatedDate: 2023-05-25T12:00:00.000Z
       </div>
     </div>
     <div class="flex flex-col sm:flex-row grid-gap rs-mb-2 text-white">
-      <div class="w-full sm:w-1/2 lg:w-3/4 bg-spirited rs-p-2">
+      <div class="w-full sm:w-1/2 lg:w-3/4 bg-plum rs-p-2">
         <h3>8 of 12 columns</h3>
         <p class="card-paragraph">This column stacks vertically for XS breakpoint; spans 6 of 12 columns for
           SM-MD; spans 8 of 12 columns for LG and up; responsive column gaps using .grid-gap class.</p>
       </div>
-      <div class="w-full sm:w-1/2 lg:w-1/4 bg-spirited-dark rs-p-2">
+      <div class="w-full sm:w-1/2 lg:w-1/4 bg-plum-dark rs-p-2">
         <h3>4 of 12 columns</h3>
         <p class="card-paragraph">This column stacks vertically for XS breakpoint; spans 6 of 12 columns for
           SM-MD; spans 4 of 12 columns for LG and up; responsive column gaps using .grid-gap class.</p>
@@ -32,7 +32,7 @@ lastUpdatedDate: 2023-05-25T12:00:00.000Z
     </div>
     ```
     <div className="flex flex-col md:flex-row gap-xs lg:gap-lg xl:gap-xl 2xl:gap-2xl text-white rs-mb-2">
-      <div className="w-full md:w-1/2 bg-palo-verde-light rs-p-2">
+      <div className="w-full md:w-1/2 bg-lagunita rs-p-2">
         <h3>6 of 12 columns</h3>
         <p className="card-paragraph">This column stacks vertically for XS-SM breakpoints and spans 6 of 12
           columns for MD and up; responsive grid gaps.</p>
@@ -44,12 +44,12 @@ lastUpdatedDate: 2023-05-25T12:00:00.000Z
       </div>
     </div>
     <div className="flex flex-col sm:flex-row grid-gap rs-mb-2 text-white">
-      <div className="w-full sm:w-1/2 lg:w-3/4 bg-spirited rs-p-2">
+      <div className="w-full sm:w-1/2 lg:w-3/4 bg-plum rs-p-2">
         <h3>8 of 12 columns</h3>
         <p className="card-paragraph">This column stacks vertically for XS breakpoint; spans 6 of 12 columns for
           SM-MD; spans 8 of 12 columns for LG and up; responsive column gaps using .grid-gap class.</p>
       </div>
-      <div className="w-full sm:w-1/2 lg:w-1/4 bg-spirited-dark rs-p-2">
+      <div className="w-full sm:w-1/2 lg:w-1/4 bg-plum-dark rs-p-2">
         <h3>4 of 12 columns</h3>
         <p className="card-paragraph">This column stacks vertically for XS breakpoint; spans 6 of 12 columns for
           SM-MD; spans 4 of 12 columns for LG and up; responsive column gaps using .grid-gap class.</p>

--- a/content/for-designers/type-grids-and-color.mdx
+++ b/content/for-designers/type-grids-and-color.mdx
@@ -82,8 +82,8 @@ lastUpdatedDate: 2022-12-30T12:00:00.000Z
     <p></p>
     #### Grids
 
-      <div className="flex flex-col md:flex-row gap-xs lg:gap-lg xl:gap-xl 2xl:gap-2xl text-white rs-mb-2">
-      <div className="w-full md:w-1/2 bg-palo-verde-light rs-p-2">
+      <div className="flex flex-col md:flex-row grid-gap text-white rs-mb-2">
+      <div className="w-full md:w-1/2 bg-lagunita rs-p-2">
         <h3>6 of 12 columns</h3>
         <p className="card-paragraph">This column stacks vertically for XS-SM breakpoints and spans 6 of 12
           columns for MD and up; responsive grid gaps.</p>
@@ -95,12 +95,12 @@ lastUpdatedDate: 2022-12-30T12:00:00.000Z
       </div>
     </div>
     <div className="flex flex-col sm:flex-row grid-gap rs-mb-2 text-white">
-      <div className="w-full sm:w-1/2 lg:w-3/4 bg-spirited rs-p-2">
+      <div className="w-full sm:w-1/2 lg:w-2/3 bg-plum rs-p-2">
         <h3>8 of 12 columns</h3>
         <p className="card-paragraph">This column stacks vertically for XS breakpoint; spans 6 of 12 columns for
           SM-MD; spans 8 of 12 columns for LG and up; responsive column gaps using .grid-gap class.</p>
       </div>
-      <div className="w-full sm:w-1/2 lg:w-1/4 bg-spirited-dark rs-p-2">
+      <div className="w-full sm:w-1/2 lg:w-1/3 bg-plum-dark rs-p-2">
         <h3>4 of 12 columns</h3>
         <p className="card-paragraph">This column stacks vertically for XS breakpoint; spans 6 of 12 columns for
           SM-MD; spans 4 of 12 columns for LG and up; responsive column gaps using .grid-gap class.</p>

--- a/content/for-developers/strategies-and-conventions.mdx
+++ b/content/for-developers/strategies-and-conventions.mdx
@@ -89,7 +89,7 @@ lastUpdatedDate: 2022-04-06T12:00:00.000Z
     <Section heading="Responsive Spacing" id="responsive-spacing">
       The Decanter design system comes with a responsive spacing strategy. The provided values will scale up and down with screen sizes to maintain optimal use of whitespace and a positive developer experience.
 
-      ###### Prefixes:
+      ### Prefixes:
 
         `rs-m-` for margin<br />
         `rs-mb-` for margin bottom<br />
@@ -169,7 +169,7 @@ lastUpdatedDate: 2022-04-06T12:00:00.000Z
       </tbody>
     </table>
 
-    ##### Example
+    #### Example
     ```html
     <!-- You can use the responsive spacing classes like so, but you wouldn't use all of them at once. -->
     <div class="rs-m-0 rs-mb-1 rs-mt-2 rs-mr-3 rs-ml-4 rs-mx-5 rs-my-6 rs-p-0 rs-pb-1 rs-pt-2 rs-pr-3 rs-pl-4 rs-px-5 rs-py-6">

--- a/styles/prism.css
+++ b/styles/prism.css
@@ -5,162 +5,163 @@
  * https://github.com/PrismJS/prism-themes
  */
 /**
- * MIT License
- * Copyright (c) 2018 Sarah Drasner
- * Sarah Drasner's[@sdras] Night Owl
- * Ported by Sara vieria [@SaraVieira]
- * Added by Souvik Mandal [@SimpleIndian]
+ * a11y-dark theme for JavaScript, CSS, and HTML
+ * Based on the okaidia theme: https://github.com/PrismJS/prism/blob/gh-pages/themes/prism-okaidia.css
+ * @author ericwbailey
  */
 
 code[class*="language-"],
 pre[class*="language-"] {
-	color: #d6deeb;
-	background-color:	#011627;
-	font-family: "Roboto Mono", Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
-	text-align: left;
-	white-space: pre;
-	word-spacing: normal;
-	word-break: normal;
-	word-wrap: normal;
-	line-height: 1.5;
-	font-size: 0.85em;
-  max-height: 40rem;
+  color: #f8f8f2;
+  background: none;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
 
-	-moz-tab-size: 4;
-	-o-tab-size: 4;
-	tab-size: 4;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
 
-	-webkit-hyphens: none;
-	-moz-hyphens: none;
-	-ms-hyphens: none;
-	hyphens: none;
-}
-
-pre[class*="language-"]::-moz-selection,
-pre[class*="language-"] ::-moz-selection,
-code[class*="language-"]::-moz-selection,
-code[class*="language-"] ::-moz-selection {
-	text-shadow: none;
-	background: rgba(29, 59, 83, 0.99);
-}
-
-pre[class*="language-"]::selection,
-pre[class*="language-"] ::selection,
-code[class*="language-"]::selection,
-code[class*="language-"] ::selection {
-	text-shadow: none;
-	background: rgba(29, 59, 83, 0.99);
-}
-
-@media print {
-	code[class*="language-"],
-	pre[class*="language-"] {
-		text-shadow: none;
-	}
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
-	padding: 1em;
-	margin: 0.5em 0;
-	overflow: auto;
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+  border-radius: 0.3em;
 }
 
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
-	color: white;
-	background: #011627;
+  background: #2b2b2b;
 }
 
+/* Inline code */
 :not(pre) > code[class*="language-"] {
-	padding: 0.1em;
-	border-radius: 0.3em;
-	white-space: normal;
+  padding: 0.1em;
+  border-radius: 0.3em;
+  white-space: normal;
 }
 
 .token.comment,
 .token.prolog,
+.token.doctype,
 .token.cdata {
-	color: rgb(99, 119, 119);
-	font-style: italic;
+  color: #d4d0ab;
 }
 
 .token.punctuation {
-	color: rgb(199, 146, 234);
+  color: #fefefe;
 }
 
-.namespace {
-	color: rgb(178, 204, 214);
-}
-
-.token.deleted {
-	color: rgba(239, 83, 80, 0.56);
-	font-style: italic;
-}
-
-.token.symbol,
-.token.property {
-	color: rgb(128, 203, 196);
-}
-
+.token.property,
 .token.tag,
-.token.operator,
-.token.keyword {
-	color: rgb(127, 219, 202);
-}
-
-.token.boolean {
-	color: rgb(255, 88, 116);
-}
-
-.token.number {
-	color: rgb(247, 140, 108);
-}
-
 .token.constant,
-.token.function,
-.token.builtin,
-.token.char {
-	color: rgb(130, 170, 255);
+.token.symbol,
+.token.deleted {
+  color: #ffa07a;
+}
+
+.token.boolean,
+.token.number {
+  color: #00e0e0;
 }
 
 .token.selector,
-.token.doctype {
-	color: rgb(199, 146, 234);
-	font-style: italic;
-}
-
 .token.attr-name,
-.token.inserted {
-	color: rgb(173, 219, 103);
-	font-style: italic;
-}
-
 .token.string,
-.token.url,
-.token.entity,
-.language-css .token.string,
-.style .token.string {
-	color: rgb(173, 219, 103);
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #abe338;
 }
 
-.token.class-name,
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+  color: #00e0e0;
+}
+
 .token.atrule,
-.token.attr-value {
-	color: rgb(255, 203, 139);
+.token.attr-value,
+.token.function {
+  color: #ffd700;
+}
+
+.token.keyword {
+  color: #00e0e0;
 }
 
 .token.regex,
-.token.important,
-.token.variable {
-	color: rgb(214, 222, 235);
+.token.important {
+  color: #ffd700;
 }
 
 .token.important,
 .token.bold {
-	font-weight: bold;
+  font-weight: bold;
 }
 
 .token.italic {
-	font-style: italic;
+  font-style: italic;
+}
+
+.token.entity {
+  cursor: help;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  code[class*="language-"],
+  pre[class*="language-"] {
+    color: windowText;
+    background: window;
+  }
+
+  :not(pre) > code[class*="language-"],
+  pre[class*="language-"] {
+    background: window;
+  }
+
+  .token.important {
+    background: highlight;
+    color: window;
+    font-weight: normal;
+  }
+
+  .token.atrule,
+  .token.attr-value,
+  .token.function,
+  .token.keyword,
+  .token.operator,
+  .token.selector {
+    font-weight: bold;
+  }
+
+  .token.attr-value,
+  .token.comment,
+  .token.doctype,
+  .token.function,
+  .token.keyword,
+  .token.operator,
+  .token.property,
+  .token.string {
+    color: highlight;
+  }
+
+  .token.attr-value,
+  .token.url {
+    font-weight: normal;
+  }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix color contrast issues
- Fix homepage missing main landmark issue
- Some heading structure fixes

# Review By (Date)
- Whenever

# Criticality
- 4

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to the homepage, inspect the code and check that we have a `main` landmark. I have the structure matched the interior pages (those have no SI issues)
2. Go to https://deploy-preview-157--decanter.netlify.app/for-developers/installation, the text inside the code blocks should be accessible in terms of color contrast. I'm using a different theme called "a11y dark" and it's looking better than the old one we used.
3. Go to a page like this https://deploy-preview-157--decanter.netlify.app/for-developers/strategies-and-conventions, see that I changed the heading level of the "On this page" nav to a h2 (previously an h3 which is not liked by SI)
4. Go to https://deploy-preview-157--decanter.netlify.app/examples/grid-flex, check that the colored grid cells have sufficient contrast with the white text in them.

# Associated Issues and/or People
- JIRA ticket(s) https://stanford.atlassian.net/browse/DS-1015
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
